### PR TITLE
ttc-dashboard-ui to 0.0.41

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.40
+  version: 0.0.41
 - name: infrastructure
   repository: https://activiti.github.io/activiti-cloud-charts/
   version: 0.2.0


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.41