### PR TITLE
ttc-connectors-processing to 1.0.22

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -22,6 +22,9 @@ dependencies:
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.45
+- name: ttc-connectors-processing
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.22
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.33


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.22