### PR TITLE
ttc-dashboard-ui to 0.0.54

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -36,7 +36,7 @@ dependencies:
   version: 1.0.23
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.53
+  version: 0.0.54
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.49


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.54