### PR TITLE
ttc-connectors-dummytwitter to 1.0.46

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -24,7 +24,7 @@ dependencies:
   version: 1.0.12
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.45
+  version: 1.0.46
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.22


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.46